### PR TITLE
Problem with large input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Description
 
-This is a fork of the original cgmlst-dists project by Tseemann (https://github.com/tseemann/cgmlst-dists).
+This is a fork of the original cgmlst-dists project by Torsten Seemann (https://github.com/tseemann/cgmlst-dists).
 
 This version allows to manage large input files and bypasses the Integer Overflow issue when the calculation of the final memory size of the distance vector is greater than MAX_INT.
 

--- a/README.md
+++ b/README.md
@@ -1,148 +1,20 @@
-[![Build Status](https://travis-ci.org/tseemann/cgmlst-dists.svg?branch=master)](https://travis-ci.org/tseemann/cgmlst-dists)
-[![License: GPLv3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Language: C99](https://img.shields.io/badge/Language-ANSI_C-orangered.svg)](https://en.wikipedia.org/wiki/ANSI_C)
+# Description
 
-# cgmlst-dists
+This is a fork of the original cgmlst-dists project by Tseemann (https://github.com/tseemann/cgmlst-dists).
 
-Calculate distance matrix from 
-cgMLST allele call tables of ChewBBACA
+This version allows to manage large input files and bypasses the Integer Overflow issue when the calculation of the final memory size of the distance vector is greater than MAX_INT.
 
-## Quick Start
-
-```
-% cat test/boring.tab
-
-FILE    G1      G2      G3      G4      G5      G6
-S1      1       INF-2   3       2       1       5
-S2      1       1       1       1       NIPH    5
-S3      1       2       3       4       1       3
-S4      1       LNF     2       4       1       3
-S5      1       2       ASM     2       1       3
-S6      2       INF-8   3       PLOT3   PLOT5   3     
-
-% cgmlst-dists test/boring.tab > distances.tab
-
-This is cgmlst-dists 0.4.0
-Loaded 6 samples x 6 allele calls
-Calulating distances... 100.00%
-Done.
-
-% cat distances.tab
-
-        S1      S2      S3      S4      S5
-S1      0       3       2       3       1
-S2      3       0       4       3       3
-S3      2       4       0       1       1
-S4      3       3       1       0       1
-S5      1       3       1       1       0
-S6      3       4       2       2       2
-```
-
-Any allelle calls that are not positive integers are converted to zero.
-The distance is the 
-[hamming distance](https://en.wikipedia.org/wiki/Hamming_distance)
-but with zeroes excluded.
-
-It works by replacing any alphabet characters,
-and the strings `PLOT5` and `PLOT3` with spaces.
-It then converts the remaining tab separated
-values to integers and ignoring negative signs.
-Anything weird is set to zero.
-
-## Installation
-
-`cgmlst-dists` is written in C and has no other dependencies.
-
-### Homebrew
-```
-brew install brewsci/bio/cgmlst-dists  # COMING IN NOV 2020
-```
-
-### Bioconda
-```
-conda install -c bioconda cgmlst-dists
-```
-
-### Source
-
-```
-git clone https://github.com/tseemann/cgmlst-dists.git
-cd cgmlst-dists
+# Compile
+```console
 make
+```
 
-# run tests
+# Check
+```console
 make check
-
-# optionally install to a specific location (default: /usr/local)
-make PREFIX=/usr/local install
 ```
+# Example of usage
 
-## Options
-
-### `cgmlst-dists -h` (help)
-
+```console
+./cgmlst-dists-64 test/100.tab > 100output.tab
 ```
-SYNOPSIS
-  Pairwise CG-MLST distance matrix from allele call tables
-USAGE
-  cgmlst-dists [options] chewbbaca.tab > distances.tsv
-OPTIONS
-  -h    Show this help
-  -v    Print version and exit
-  -q    Quiet mode; do not print progress information
-  -c    Use comma instead of tab in output
-  -m N  Output: 1=lower-tri 2=upper-tri 3=full [3]
-  -x N  Stop calculating beyond this distance [9999]
-URL
-  https://github.com/tseemann/cgmlst-dists
-```
-
-### `cgmlst-dists -v` (version)
-
-Prints the name and version separated by a space in standard Unix fashion.
-
-```
-cgmlst-dists 0.4.0
-```
-
-### `cgmlst-dists -q` (quiet mode)
-
-Don't print informational messages, only errors.
-
-### `cgmlst-dists -c` (CSV mode)
-
-Use a comma instead of a tab in the output table.
-
-### `cgmlst-dists -m N` (output matrix format)
-
-The output matrix is diagonal symmetric because _dist(A,B)=dist(B,A)_.
-This means we only calculate half the matrix and mirror it.
-You can choose to output the lower triangle, upper triangle, or both:
-* `-m 1` lower triangle only
-* `-m 2` upper triangle only
-* `-m 3` both triangle / full matrix (default)
-
-### `cgmlst-dists -x N` (short-circuit divergent pairs)
-
-The slowest part of the algorithm is calculating the distance
-between two allele vectors. This option will stop comparing as
-soon as the distance (differences) exceeds `-x`, and return
-the distance as `-x`.
-
-## Issues
-
-Report bugs and give suggesions on the
-[Issues page](https://github.com/tseemann/cgmlst-dists/issues)
-
-## Related software
-
-* [chewBBACA](https://github.com/B-UMMI/chewBBACA)
-* [snp-dists](https://github.com/tseemann/snp-dists)
-
-## Licence
-
-[GPL Version 3](https://raw.githubusercontent.com/tseemann/cgmlst-dists/master/LICENSE)
-
-## Authors
-
-* [Torsten Seemann](https://github.com/tseemann)

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ make check
 # Example of usage
 
 ```console
-./cgmlst-dists-64 test/100.tab > 100output.tab
+./cgmlst-dists test/100.tab > 100output.tab
 ```


### PR DESCRIPTION
we have investigated the issue with cgmls-dists in handling large input files (the error has been reported with 80k Lm samples) . The tool goes in segmentation fault.
The bug is due to an incorrect memory allocation for the distance vector. The memory size is calculated as nrow*nrow which generates an Integer Overflow for a large nrow and using 32 bits (line 219 on the original version).
The maximum value that can be stored in an int variable is 2147483647 (in our case, the final dist vector size might be 80000*80000 = 6.400.000.000 > 2.147.483.647). This is due to the fact that the tool uses a vector and treats it as a matrix, which is a nice optimization.

We just imported the inttypes.h library to bypass the overflow using 64 bits. We have successfully tested on 80,000 samples and 1,748 loci.

We look forward to your feedback on this.
Best
Adriano