### PR TITLE
Fix memory allocation: Compute distance matrix row-by-row to reduce memory use

### DIFF
--- a/main.c
+++ b/main.c
@@ -57,9 +57,14 @@ int distance(const int* restrict a, const int* restrict b, size_t len, int maxdi
 //------------------------------------------------------------------------
 void* calloc_safe(size_t nmemb, size_t size) 
 {
+  if (size && nmemb > ((size_t)-1) / size) {
+    fprintf(stderr, "ERROR: allocation size overflow (%zu x %zu bytes)\n", nmemb, size);
+    exit(EXIT_FAILURE);
+  }
+  size_t bytes = nmemb * size;
   void* ptr = calloc(nmemb, size);
   if (ptr == NULL) {
-    fprintf(stderr, "ERROR: could not allocate %ld kb RAM\n", (nmemb*size)>>10);
+    fprintf(stderr, "ERROR: could not allocate %zu kb RAM\n", bytes>>10);
     exit(EXIT_FAILURE);
   }
   return ptr;
@@ -193,7 +198,7 @@ int main(int argc, char* argv[])
             exit(EXIT_FAILURE);
           }
           id[row] = strdup(s);
-          call[row] = (int*) calloc_safe(ncol, sizeof(int*));
+          call[row] = (int*) calloc_safe(ncol, sizeof(int));
         }
         else {
           // INF-xxxx are returned as -ve numbers
@@ -226,20 +231,10 @@ int main(int argc, char* argv[])
   // what we collected
   if (!quiet) fprintf(stderr, "\rLoaded %d samples x %d allele calls\n", nrow, ncol);
 
-  // build an output matrix (one dimensional j*nrow+i access)
-  int* dist = calloc_safe(nrow*nrow, sizeof(int));
-  
-  #pragma omp parallel for schedule(static, 1)
-  for (int j=0; j < nrow; j++) {
-    if (!quiet && omp_get_thread_num()==0) {
-      fprintf(stderr, "\rCalculating distances: %.2f%%", (j+1)*100.0/nrow);
-    }
-    for (int i=0; i < j; i++) {
-      int d = distance(call[j], call[i], ncol, maxdiff);
-      dist[j*nrow+i] = dist[i*nrow+j] = d;  // matrix is diagonal symetric
-    }
-  }
-  if (!quiet) fprintf(stderr, "\nWriting distance matrix to stdout...\n");
+  // build one output row at a time instead of storing the full square matrix
+  int* dist = nrow > 0 ? calloc_safe(nrow, sizeof(int)) : NULL;
+
+  if (!quiet) fprintf(stderr, "Writing distance matrix to stdout...\n");
 
   // separator choice
  
@@ -253,14 +248,24 @@ int main(int argc, char* argv[])
 
   // Print matrix
   for (int j=0; j < nrow; j++) {
-    printf("%s", id[j]);
+    if (!quiet) {
+      fprintf(stderr, "\rCalculating distances: %.2f%%", (j+1)*100.0/nrow);
+    }
     int start = (mode & 1) ?    0 : j   ;  // upper?
     int end   = (mode & 2) ? nrow : j+1 ;  // lower?
+
+    #pragma omp parallel for schedule(static, 1)
     for (int i=start; i < end; i++) {
-      printf("%c%d", sep, dist[j*nrow + i]);
+      dist[i] = (i == j) ? 0 : distance(call[j], call[i], ncol, maxdiff);
+    }
+
+    printf("%s", id[j]);
+    for (int i=start; i < end; i++) {
+      printf("%c%d", sep, dist[i]);
     }
     printf("\n");
   }
+  if (!quiet) fprintf(stderr, "\n");
 
   // free RAM
   for (int i=0; i < nrow; i++) {
@@ -278,4 +283,3 @@ int main(int argc, char* argv[])
 }
 
 //------------------------------------------------------------------------
-


### PR DESCRIPTION
## Summary

This PR fixes memory allocation failures when running `cgmlst-dists` on large datasets.

The previous implementation allocated the full `nrow x nrow` distance matrix before writing output. For tens of thousands of samples, this requires many GB of RAM and can also overflow integer arithmetic before allocation. For example, 46k samples require over 2 billion matrix cells.

This PR changes the distance calculation to compute and print one output row at a time, avoiding the full in-memory distance matrix while preserving the existing output formats.

## Changes

- Compute distances row-by-row instead of allocating the full distance matrix.
- Keep OpenMP parallelisation over the per-row distance calculations.
- Add allocation overflow checking in `calloc_safe()`.
- Fix an allocation-size bug where allele calls used `sizeof(int*)` instead of `sizeof(int)`.
- Use `%zu` when reporting `size_t` allocation sizes.

## Testing

- Compared old and new outputs on bundled test data:
  - `test/boring.tab`
  - `test/chewie.tab`
  - `test/100.tab`
- Verified modes:
  - `-m 1`
  - `-m 2`
  - `-m 3`
- Verified CSV output with `-c`.
- Verified quiet mode with `-q`.
- Tested on a real dataset with ~46k samples where the previous version failed with a memory allocation error.
- Confirmed output matches the previous implementation when using the same parameters on datasets where the previous implementation could complete.
